### PR TITLE
fix executemany method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.12.1
+VERSION=1.12.2
 TARDIR=/tmp/$(USER)
 TARFILE=$(TARDIR)/wsdbtools_$(VERSION).tar
 BUILDDIR=$(HOME)/build/wsdbtools

--- a/wsdbtools/transaction.py
+++ b/wsdbtools/transaction.py
@@ -34,7 +34,7 @@ class Transaction(object):
         if not self.InTransaction:
             raise RuntimeError("Not in transaction")
         try:
-            self.Cursor.execute(*params, **args)
+            self.Cursor.executemany(*params, **args)
         except:
             self.rollback()
             raise


### PR DESCRIPTION
I'm pretty sure the executemany method was supposed to call executemany, not execute... anyhow this is needed
to fix` metacat file update-meta`. 